### PR TITLE
fix: correct bugs and remove legacy code

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -32,7 +32,7 @@ mkdir -p "$(dirname "$clone_path")"
 
 # Clone the repo
 echo "Cloning dotfiles repository..."
-git clone http://github.com/alienlebarge/dotfiles "$clone_path"
+git clone https://github.com/alienlebarge/dotfiles "$clone_path"
 
 # Change to the dotfiles directory
 cd "$clone_path" || exit 1

--- a/brew.sh
+++ b/brew.sh
@@ -42,10 +42,6 @@ brew install ponysay
 # a replacement for `ls`
 brew install eza
 
-# Install lsd
-# a better ls https://github.com/lsd-rs/
-brew install lsd
-
 # Install Ack
 # https://beyondgrep.com/
 brew install ack
@@ -110,7 +106,7 @@ brew install borders
 brew cleanup
 
 # Install json, a fast CLI tool for working with JSON
-npm install ---global json
+npm install --global json
 
 # Install trash
 # https://github.com/sindresorhus/trash

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -20,14 +20,14 @@
     # `git di $number` shows the diff between the state `$number` revisions ago and the current state
     di = !"d() { git diff --patch-with-stat HEAD~$1; }; git diff-index --quiet HEAD -- || clear; d"
 
-    # Show the diff between the current branch and the master
-    dim = !"git diff origin/master"
+    # Show the diff between the current branch and main
+    dim = !"git diff origin/main"
 
     # Show the diff between the current branch and the develop
     did = !"git diff origin/develop"
 
     # Pull in remote changes for the current repository and all its submodules
-    p = !"git pull; git submodule foreach git pull origin master"
+    p = !"git pull; git submodule foreach git pull origin main"
 
     # Clone a repository including all submodules
     c = clone --recursive
@@ -67,7 +67,7 @@
     # Find commits by commit message
     fm = "!f() { git log --pretty=format:'%C(yellow)%h  %Cblue%ad  %Creset%s%Cgreen  [%cn] %Cred%d' --decorate --date=short --grep=$1; }; f"
 
-    # Remove branches that have already been merged with master
+    # Remove branches that have already been merged with main
     # a.k.a. ‘delete merged’
     dm = "!git branch --merged | grep -v '\\*' | xargs -n 1 git branch -d"
 
@@ -75,7 +75,7 @@
     # see https://salferrarello.com/git-delete-merged-branches-from-remote/
     dmo = "!git branch --all --merged remotes/origin/main | grep --invert-match main | grep --invert-match HEAD | grep "remotes/origin/" | cut -d "/" -f 3- | xargs -n 1 git push --delete origin"
 
-    # Remove branches on the remote `GitHub` that have already been merged with GitHub/master
+    # Remove branches on the remote `GitHub` that have already been merged with GitHub/main
     # see https://salferrarello.com/git-delete-merged-branches-from-remote/
     dmg  = "!git branch --all --merged remotes/GitHub/main | grep --invert-match main | grep --invert-match HEAD | grep "remotes/GitHub/" | cut -d "/" -f 3- | xargs -n 1 git push --delete GitHub"
 
@@ -101,12 +101,12 @@
     # See which commits are on your local branch that aren’t on the remote
     local = "! git log --oneline --no-merges origin/$(git rev-parse --abbrev-ref HEAD).."
 
-    # Merge GitHub pull request on top of the `master` branch
+    # Merge GitHub pull request on top of the `main` branch
     mpr = "!f() { \
         if [ $(printf \"%s\" \"$1\" | grep '^[0-9]\\+$' > /dev/null; printf $?) -eq 0 ]; then \
             git fetch origin refs/pull/$1/head:pr/$1 && \
-            git rebase master pr/$1 && \
-            git checkout master && \
+            git rebase main pr/$1 && \
+            git checkout main && \
             git merge pr/$1 && \
             git branch -D pr/$1 && \
             git commit --amend -m \"$(git log -1 --pretty=%B)\n\nCloses #$1.\"; \

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -52,26 +52,6 @@ alias j="jobs"
 alias yolo="claude --dangerously-skip-permissions"
 alias gcauto="git commit -m \"\$(claude -p 'Please review all the changes that have been staged in the Git repository and create a commit summary. Follow these guidelines for the commit message structure: <type>[optional scope]: <description>. Use types like feat, fix, docs, style, refactor, test, and chore. Optionally, add scope for further context. Provide a concise description, and ensure the message is clear and informative. Only respond with the commit message.')\""
 
-# Detect which `ls` flavor is in use
-if ls --color > /dev/null 2>&1; then # GNU `ls`
-	colorflag="--color"
-else # OS X `ls`
-	colorflag="-G"
-fi
-
-# List all files colorized in long format
-#alias l="ls -lF ${colorflag}"
-
-# List all files colorized in long format, including dot files
-#alias la="ls -laF ${colorflag}"
-
-# List only directories
-#alias lsd="ls -lF ${colorflag} | grep --color=never '^d'"
-
-# Always use color output for `ls`
-#alias ls="command ls ${colorflag}"
-#export LS_COLORS='no=00:fi=00:di=01;34:ln=01;36:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arj=01;31:*.taz=01;31:*.lzh=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.gz=01;31:*.bz2=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.avi=01;35:*.fli=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.ogg=01;35:*.mp3=01;35:*.wav=01;35:'
-
 # ld — lists only directories (no files)
 alias ld="eza -lD"
 # lf — lists only files (no directories)


### PR DESCRIPTION
## Summary

- **`brew.sh`**: fix triple-dash typo in `npm install ---global json` (caused silent failure)
- **`brew.sh`**: remove unused `lsd` install — only `eza` is used in aliases
- **`bootstrap.sh`**: use `https://` instead of `http://` for git clone URL
- **`.gitconfig`**: update `master` → `main` in `dim`, `p`, and `mpr` aliases and their comments
- **`.zshrc`**: remove dead `colorflag` detection block and all commented-out legacy `ls` aliases (superseded by `eza`)

## Test plan

- [ ] Run `brew.sh` on a fresh machine and verify `npm install --global json` succeeds
- [ ] Verify `git p` pulls submodules from `main` correctly
- [ ] Verify `git dim` diffs against `origin/main`
- [ ] Confirm `.zshrc` sources cleanly with no errors (`source ~/.zshrc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)